### PR TITLE
Adjust OS family for OS X profile activation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
 			<id>OSX-profile</id>
 			<activation>
 				<os>
-					<family>OSX</family>
+					<family>mac</family>
 				</os>
 			</activation>
 			<properties>


### PR DESCRIPTION
I found that in order for maven to download the native libraries on Mac OS it was necessary to adjust the os family for the correct maven profile to activate.

The value 'OSX' is not one of the values [listed](https://maven.apache.org/enforcer/enforcer-rules/requireOS.html) only 'mac' seems to apply. The above link is referenced in the [maven documentation](http://maven.apache.org/guides/introduction/introduction-to-profiles.html#Details_on_profile_activation):

> This next one will activate based on OS settings. See the Maven Enforcer Plugin for more details about OS values.