### PR TITLE
Optimize the Transformation class

### DIFF
--- a/chapter21/c21-p1/src/main/java/org/lwjglb/engine/graph/Renderer.java
+++ b/chapter21/c21-p1/src/main/java/org/lwjglb/engine/graph/Renderer.java
@@ -415,7 +415,7 @@ public class Renderer {
             for (GameItem gameItem : hud.getGameItems()) {
                 Mesh mesh = gameItem.getMesh();
                 // Set ortohtaphic and model matrix for this HUD item
-                Matrix4f projModelMatrix = transformation.buildOrtoProjModelMatrix(gameItem, ortho);
+                Matrix4f projModelMatrix = transformation.buildOrthoProjModelMatrix(gameItem, ortho);
                 hudShaderProgram.setUniform("projModelMatrix", projModelMatrix);
                 hudShaderProgram.setUniform("colour", gameItem.getMesh().getMaterial().getColour());
                 hudShaderProgram.setUniform("hasTexture", gameItem.getMesh().getMaterial().isTextured() ? 1 : 0);

--- a/chapter21/c21-p1/src/main/java/org/lwjglb/engine/graph/Transformation.java
+++ b/chapter21/c21-p1/src/main/java/org/lwjglb/engine/graph/Transformation.java
@@ -1,14 +1,11 @@
 package org.lwjglb.engine.graph;
 
 import org.joml.Matrix4f;
+import org.joml.Quaternionf;
 import org.joml.Vector3f;
 import org.lwjglb.engine.items.GameItem;
 
 public class Transformation {
-
-    private static final Vector3f X_AXIS = new Vector3f(1, 0, 0);
-    
-    private static final Vector3f Y_AXIS = new Vector3f(0, 1, 0);
 
     private final Matrix4f projectionMatrix;
 
@@ -16,8 +13,6 @@ public class Transformation {
     
     private final Matrix4f modelViewMatrix;
 
-    private final Matrix4f modelLightMatrix;
-    
     private final Matrix4f modelLightViewMatrix;
 
     private final Matrix4f viewMatrix;
@@ -34,7 +29,6 @@ public class Transformation {
         projectionMatrix = new Matrix4f();
         modelMatrix = new Matrix4f();
         modelViewMatrix = new Matrix4f();
-        modelLightMatrix = new Matrix4f();
         modelLightViewMatrix = new Matrix4f();
         viewMatrix = new Matrix4f();
         orthoProjMatrix = new Matrix4f();
@@ -49,9 +43,7 @@ public class Transformation {
     
     public Matrix4f updateProjectionMatrix(float fov, float width, float height, float zNear, float zFar) {
         float aspectRatio = width / height;        
-        projectionMatrix.identity();
-        projectionMatrix.perspective(fov, aspectRatio, zNear, zFar);
-        return projectionMatrix;
+        return projectionMatrix.setPerspective(fov, aspectRatio, zNear, zFar);
     }
 
     public final Matrix4f getOrthoProjectionMatrix() {
@@ -59,9 +51,7 @@ public class Transformation {
     }
 
     public Matrix4f updateOrthoProjectionMatrix(float left, float right, float bottom, float top, float zNear, float zFar) {
-        orthoProjMatrix.identity();
-        orthoProjMatrix.setOrtho(left, right, bottom, top, zNear, zFar);
-        return orthoProjMatrix;
+        return orthoProjMatrix.setOrtho(left, right, bottom, top, zNear, zFar);
     }
 
     public Matrix4f getViewMatrix() {
@@ -85,70 +75,41 @@ public class Transformation {
     }
 
     private Matrix4f updateGenericViewMatrix(Vector3f position, Vector3f rotation, Matrix4f matrix) {
-        matrix.identity();
         // First do the rotation so camera rotates over its position
-        matrix.rotate((float)Math.toRadians(rotation.x), X_AXIS)
-                .rotate((float)Math.toRadians(rotation.y), Y_AXIS);
-        // Then do the translation
-        matrix.translate(-position.x, -position.y, -position.z);
-        return matrix;
+        return matrix.rotationX((float)Math.toRadians(rotation.x))
+                     .rotateY((float)Math.toRadians(rotation.y))
+                     .translate(-position.x, -position.y, -position.z);
     }
 
     public final Matrix4f getOrtho2DProjectionMatrix(float left, float right, float bottom, float top) {
-        ortho2DMatrix.identity();
-        ortho2DMatrix.setOrtho2D(left, right, bottom, top);
-        return ortho2DMatrix;
+        return ortho2DMatrix.setOrtho2D(left, right, bottom, top);
     }
     
     public Matrix4f buildModelMatrix(GameItem gameItem) {
-        Vector3f rotation = gameItem.getRotation();
-        modelMatrix.identity().translate(gameItem.getPosition()).                
-                rotateX((float)Math.toRadians(-rotation.x)).
-                rotateY((float)Math.toRadians(-rotation.y)).
-                rotateZ((float)Math.toRadians(-rotation.z)).
-                scale(gameItem.getScale());
-        return modelMatrix;
+        Quaternionf rotation = gameItem.getRotation();
+        return modelMatrix.translationRotateScale(
+                gameItem.getPosition().x, gameItem.getPosition().y, gameItem.getPosition().z,
+                rotation.x, rotation.y, rotation.z, rotation.w,
+                gameItem.getScale(), gameItem.getScale(), gameItem.getScale());
     }
 
     public Matrix4f buildModelViewMatrix(GameItem gameItem, Matrix4f viewMatrix) {
-        Vector3f rotation = gameItem.getRotation();
-        modelMatrix.identity().translate(gameItem.getPosition()).                
-                rotateX((float)Math.toRadians(-rotation.x)).
-                rotateY((float)Math.toRadians(-rotation.y)).
-                rotateZ((float)Math.toRadians(-rotation.z)).
-                scale(gameItem.getScale());
-        return buildModelViewMatrix(modelMatrix, viewMatrix);
+        return buildModelViewMatrix(buildModelMatrix(gameItem), viewMatrix);
     }
     
     public Matrix4f buildModelViewMatrix(Matrix4f modelMatrix, Matrix4f viewMatrix) {
-        modelViewMatrix.set(viewMatrix);
-        return modelViewMatrix.mul(modelMatrix);
+        return viewMatrix.mulAffine(modelMatrix, modelViewMatrix);
     }
 
     public Matrix4f buildModelLightViewMatrix(GameItem gameItem, Matrix4f lightViewMatrix) {
-        Vector3f rotation = gameItem.getRotation();
-        modelMatrix.identity().translate(gameItem.getPosition()).
-                rotateX((float)Math.toRadians(-rotation.x)).
-                rotateY((float)Math.toRadians(-rotation.y)).
-                rotateZ((float)Math.toRadians(-rotation.z)).
-                scale(gameItem.getScale());
-        return buildModelViewMatrix(modelMatrix, lightViewMatrix);
+        return buildModelViewMatrix(buildModelMatrix(gameItem), lightViewMatrix);
     }
 
-    public Matrix4f buildModelLightViewMatrix(Matrix4f modelMatrix, Matrix4f lighViewMatrix) {
-        modelLightViewMatrix.set(lighViewMatrix);
-        return modelLightViewMatrix.mul(modelMatrix);
+    public Matrix4f buildModelLightViewMatrix(Matrix4f modelMatrix, Matrix4f lightViewMatrix) {
+        return lightViewMatrix.mulAffine(modelMatrix, modelLightViewMatrix);
     }
 
-    public Matrix4f buildOrtoProjModelMatrix(GameItem gameItem, Matrix4f orthoMatrix) {
-        Vector3f rotation = gameItem.getRotation();
-        modelMatrix.identity().translate(gameItem.getPosition()).
-                rotateX((float) Math.toRadians(-rotation.x)).
-                rotateY((float) Math.toRadians(-rotation.y)).
-                rotateZ((float) Math.toRadians(-rotation.z)).
-                scale(gameItem.getScale());
-        orthoModelMatrix.set(orthoMatrix);
-        orthoModelMatrix.mul(modelMatrix);
-        return orthoModelMatrix;
+    public Matrix4f buildOrthoProjModelMatrix(GameItem gameItem, Matrix4f orthoMatrix) {
+        return orthoMatrix.mulOrthoAffine(buildModelMatrix(gameItem), orthoModelMatrix);
     }
 }

--- a/chapter21/c21-p1/src/main/java/org/lwjglb/engine/graph/particles/Particle.java
+++ b/chapter21/c21-p1/src/main/java/org/lwjglb/engine/graph/particles/Particle.java
@@ -34,8 +34,7 @@ public class Particle extends GameItem {
         super(baseParticle.getMesh());
         Vector3f aux = baseParticle.getPosition();
         setPosition(aux.x, aux.y, aux.z);
-        aux = baseParticle.getRotation();
-        setRotation(aux.x, aux.y, aux.z);
+        setRotation(baseParticle.getRotation());
         setScale(baseParticle.getScale());
         this.speed = new Vector3f(baseParticle.speed);
         this.ttl = baseParticle.geTtl();

--- a/chapter21/c21-p1/src/main/java/org/lwjglb/engine/items/GameItem.java
+++ b/chapter21/c21-p1/src/main/java/org/lwjglb/engine/items/GameItem.java
@@ -1,5 +1,6 @@
 package org.lwjglb.engine.items;
 
+import org.joml.Quaternionf;
 import org.joml.Vector3f;
 import org.lwjglb.engine.graph.Mesh;
 
@@ -11,14 +12,14 @@ public class GameItem {
 
     private float scale;
 
-    private final Vector3f rotation;
+    private final Quaternionf rotation;
 
     private int textPos;
             
     public GameItem() {
         position = new Vector3f(0, 0, 0);
         scale = 1;
-        rotation = new Vector3f(0, 0, 0);
+        rotation = new Quaternionf();
         textPos = 0;
     }
 
@@ -54,14 +55,12 @@ public class GameItem {
         this.scale = scale;
     }
 
-    public Vector3f getRotation() {
+    public Quaternionf getRotation() {
         return rotation;
     }
 
-    public final void setRotation(float x, float y, float z) {
-        this.rotation.x = x;
-        this.rotation.y = y;
-        this.rotation.z = z;
+    public final void setRotation(Quaternionf q) {
+        this.rotation.set(q);
     }
 
     public Mesh getMesh() {


### PR DESCRIPTION
This commit does not change the semantics of any method.
This commit only applies the changes to the latest demo c21-p1.

Profiling the application showed a big overhead for JOML methods, especially the rotate*() methods, which call java.lang.Math.sin/cos. These changes optimize the use of JOML to the point where no JOML method is within 0.01% of the application's CPU usage anymore:
- use fast Matrix4f.translationRotateScale() to build a model transformation (this is a dedicated method to build the common T * R * S transformation)
- use Quaternionf rather than three Euler angles to avoid calling sin/cos many times per frame when building the model transformation for each GameItem

Others:
- small typo
- refactor Transformation to reuse buildModelMatrix() in various places