### PR TITLE
Memory Allocation Updates

### DIFF
--- a/chapter04/src/main/java/org/lwjglb/game/Renderer.java
+++ b/chapter04/src/main/java/org/lwjglb/game/Renderer.java
@@ -1,7 +1,7 @@
 package org.lwjglb.game;
 
 import java.nio.FloatBuffer;
-import org.lwjgl.BufferUtils;
+import static org.lwjgl.system.MemoryUtil.*;
 import static org.lwjgl.opengl.GL11.*;
 import static org.lwjgl.opengl.GL15.*;
 import static org.lwjgl.opengl.GL20.*;
@@ -33,7 +33,8 @@ public class Renderer {
             0.5f,  -0.5f, 0.0f
         };
 
-        FloatBuffer verticesBuffer = BufferUtils.createFloatBuffer(vertices.length);
+        // Allocate some off-heap memory for the verticiesBuffer
+        FloatBuffer verticesBuffer = memAllocFloat(vertices.length);
         verticesBuffer.put(vertices).flip();
 
         // Create the VAO and bind to it
@@ -44,6 +45,10 @@ public class Renderer {
         vboId = glGenBuffers();
         glBindBuffer(GL_ARRAY_BUFFER, vboId);
         glBufferData(GL_ARRAY_BUFFER, verticesBuffer, GL_STATIC_DRAW);
+        
+        // Free the memory allocated for the verticiesBuffer
+        memFree(verticiesBuffer);
+        
         // Define structure of the data
         glVertexAttribPointer(0, 3, GL_FLOAT, false, 0, 0);
 

--- a/chapter05/c05-p1/src/main/java/org/lwjglb/engine/graph/Mesh.java
+++ b/chapter05/c05-p1/src/main/java/org/lwjglb/engine/graph/Mesh.java
@@ -2,7 +2,7 @@ package org.lwjglb.engine.graph;
 
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
-import org.lwjgl.BufferUtils;
+import static org.lwjgl.system.MemoryUtil.*;
 import static org.lwjgl.opengl.GL11.*;
 import static org.lwjgl.opengl.GL15.*;
 import static org.lwjgl.opengl.GL20.*;
@@ -26,19 +26,20 @@ public class Mesh {
 
         // Position VBO
         posVboId = glGenBuffers();
-        FloatBuffer posBuffer = BufferUtils.createFloatBuffer(positions.length);
+        FloatBuffer posBuffer = memAllocFloat(positions.length);
         posBuffer.put(positions).flip();
         glBindBuffer(GL_ARRAY_BUFFER, posVboId);
         glBufferData(GL_ARRAY_BUFFER, posBuffer, GL_STATIC_DRAW);
+        memFree(posBuffer);
         glVertexAttribPointer(0, 3, GL_FLOAT, false, 0, 0);
 
         // Index VBO
         idxVboId = glGenBuffers();
-        IntBuffer indicesBuffer = BufferUtils.createIntBuffer(indices.length);
+        IntBuffer indicesBuffer = memAllocInt(indices.length);
         indicesBuffer.put(indices).flip();
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, idxVboId);
         glBufferData(GL_ELEMENT_ARRAY_BUFFER, indicesBuffer, GL_STATIC_DRAW);
-
+        memFree(indicesBuffer);
         glBindBuffer(GL_ARRAY_BUFFER, 0);
         glBindVertexArray(0);
     }

--- a/chapter05/c05-p2/src/main/java/org/lwjglb/engine/graph/Mesh.java
+++ b/chapter05/c05-p2/src/main/java/org/lwjglb/engine/graph/Mesh.java
@@ -2,7 +2,7 @@ package org.lwjglb.engine.graph;
 
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
-import org.lwjgl.BufferUtils;
+import static org.lwjgl.system.MemoryUtil.*;
 import static org.lwjgl.opengl.GL11.*;
 import static org.lwjgl.opengl.GL15.*;
 import static org.lwjgl.opengl.GL20.*;
@@ -28,27 +28,29 @@ public class Mesh {
 
         // Position VBO
         posVboId = glGenBuffers();
-        FloatBuffer posBuffer = BufferUtils.createFloatBuffer(positions.length);
+        FloatBuffer posBuffer = memAllocFloat(positions.length);
         posBuffer.put(positions).flip();
         glBindBuffer(GL_ARRAY_BUFFER, posVboId);
         glBufferData(GL_ARRAY_BUFFER, posBuffer, GL_STATIC_DRAW);
+        memFree(posBuffer);
         glVertexAttribPointer(0, 3, GL_FLOAT, false, 0, 0);
         
         // Colour VBO
         colourVboId = glGenBuffers();
-        FloatBuffer colourBuffer = BufferUtils.createFloatBuffer(colours.length);
+        FloatBuffer colourBuffer = memAllocFloat(colours.length);
         colourBuffer.put(colours).flip();
         glBindBuffer(GL_ARRAY_BUFFER, colourVboId);
         glBufferData(GL_ARRAY_BUFFER, colourBuffer, GL_STATIC_DRAW);
+        memFree(colourBuffer);
         glVertexAttribPointer(1, 3, GL_FLOAT, false, 0, 0);
 
         // Index VBO
         idxVboId = glGenBuffers();
-        IntBuffer indicesBuffer = BufferUtils.createIntBuffer(indices.length);
+        IntBuffer indicesBuffer = memAllocInt(indices.length);
         indicesBuffer.put(indices).flip();
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, idxVboId);
         glBufferData(GL_ELEMENT_ARRAY_BUFFER, indicesBuffer, GL_STATIC_DRAW);
-
+        memFree(indicesBuffer);
         glBindBuffer(GL_ARRAY_BUFFER, 0);
         glBindVertexArray(0);
     }


### PR DESCRIPTION
Updates to the source code for chapter 4 and 5 (Rendering and More on Rendering) to remove the BufferUtils method for off-heap memory allocation and instead use the memAlloc methods provided in org.lwjgl.system.MemoryUtil.

The memFree method calls have been placed immediately after the buffers are accessed by the OpenGL library. These calls could be moved if it's felt that improves readability of the code.