### PR TITLE
SpotLight pointLight bug

### DIFF
--- a/chapter11/c11-p2/src/main/java/org/lwjglb/game/DummyGame.java
+++ b/chapter11/c11-p2/src/main/java/org/lwjglb/game/DummyGame.java
@@ -84,12 +84,12 @@ public class DummyGame implements IGameLogic {
 
         // Spot Light
         lightPosition = new Vector3f(0, 0.0f, 10f);
-        pointLight = new PointLight(new Vector3f(1, 1, 1), lightPosition, lightIntensity);
+        PointLight sl_pointLight = new PointLight(new Vector3f(1, 1, 1), lightPosition, lightIntensity);
         att = new PointLight.Attenuation(0.0f, 0.0f, 0.02f);
-        pointLight.setAttenuation(att);
+        sl_pointLight.setAttenuation(att);
         Vector3f coneDir = new Vector3f(0, 0, -1);
         float cutoff = (float) Math.cos(Math.toRadians(140));
-        spotLight = new SpotLight(pointLight, coneDir, cutoff);
+        spotLight = new SpotLight(sl_pointLight, coneDir, cutoff);
 
         lightPosition = new Vector3f(-1, 0, 0);
         directionalLight = new DirectionalLight(new Vector3f(1, 1, 1), lightPosition, lightIntensity);


### PR DESCRIPTION
fixes bug where pointLight instance is overwritten by SpotLight
Someone please check this because I'm still having issues getting the spotlight tutorial to work. But absolutely the spotLight's internal pointLight isn't supposed to be the same as the global pointLight.