### PR TITLE
Fixing a memory leak

### DIFF
--- a/chapter28/src/main/java/org/lwjglb/engine/graph/Texture.java
+++ b/chapter28/src/main/java/org/lwjglb/engine/graph/Texture.java
@@ -79,8 +79,9 @@ public class Texture {
             glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, this.width, this.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, decodedImage);
             // Generate Mip Map
             glGenerateMipmap(GL_TEXTURE_2D);
-
+            
             stbi_image_free(imageData);
+            MemoryUtil.memFree(decodedImage);
         }
     }
 


### PR DESCRIPTION
I noticed that this change gets rid of the following memory leak message that we get when we close the application with the lwjglx debugger:

[LWJGL] 16777217 bytes leaked, thread 1 (main), address: 0x20F031D5040
	at org.lwjgl.stb.STBImage.nstbi_load_from_memory(Native Method)
	at org.lwjgl.stb.STBImage.stbi_load_from_memory(STBImage.java:259)
	at org.lwjglx.debug.$Proxy$30.stbi_load_from_memory128(Unknown Source)
	at org.lwjglb.engine.graph.Texture.<init>(Texture.java:65)
	at org.lwjglb.engine.graph.Texture.<init>(Texture.java:55)
	at org.lwjglb.engine.loaders.assimp.TextureCache.getTexture(TextureCache.java:27)
	at org.lwjglb.engine.loaders.assimp.StaticMeshesLoader.processMaterial(StaticMeshesLoader.java:97)
	at org.lwjglb.engine.loaders.assimp.StaticMeshesLoader.load(StaticMeshesLoader.java:52)
	at org.lwjglb.engine.loaders.assimp.StaticMeshesLoader.load(StaticMeshesLoader.java:36)
	at org.lwjglb.game.DummyGame.init(DummyGame.java:61)
	at org.lwjglb.engine.GameEngine.init(GameEngine.java:53)
	at org.lwjglb.engine.GameEngine.run(GameEngine.java:40)
	at org.lwjglb.game.Main.main(Main.java:20)