### PR TITLE
Call glGetProgramInfoLog instead of glGetShaderInfoLog

### DIFF
--- a/chapter05/c05-p2/src/main/java/org/lwjglb/engine/graph/ShaderProgram.java
+++ b/chapter05/c05-p2/src/main/java/org/lwjglb/engine/graph/ShaderProgram.java
@@ -58,7 +58,7 @@ public class ShaderProgram {
 
         glValidateProgram(programId);
         if (glGetProgrami(programId, GL_VALIDATE_STATUS) == 0) {
-            System.out.println("Warning validating Shader code: " + glGetShaderInfoLog(programId, 1024));
+            System.out.println("Warning validating Shader code: " + glGetProgramInfoLog(programId, 1024));
         }
     }
 


### PR DESCRIPTION
All chapters except chpt5-2 use glGetProgramInfoLog.
Update to make this consistent.