### PR TITLE
added identity() to wordlMatrix

### DIFF
--- a/chapter06/c06-p2/src/main/java/org/lwjglb/engine/graph/Transformation.java
+++ b/chapter06/c06-p2/src/main/java/org/lwjglb/engine/graph/Transformation.java
@@ -19,7 +19,7 @@ public class Transformation {
     }
     
     public Matrix4f getWorldMatrix(Vector3f offset, Vector3f rotation, float scale) {
-        return worldMatrix.translation(offset).
+        return worldMatrix.identity().translation(offset).
                 rotateX((float)Math.toRadians(rotation.x)).
                 rotateY((float)Math.toRadians(rotation.y)).
                 rotateZ((float)Math.toRadians(rotation.z)).


### PR DESCRIPTION
The worldMatrix needs to be reset to the identity each call, so that it's possible to calculate the Matrix from beginning state