### PR TITLE
Add missing light intensity when calculating specular component.

### DIFF
--- a/chapter10/src/main/resources/shaders/fragment.fs
+++ b/chapter10/src/main/resources/shaders/fragment.fs
@@ -74,7 +74,7 @@ vec4 calcPointLight(PointLight light, vec3 position, vec3 normal)
     vec3 reflected_light = normalize(reflect(from_light_source, normal));
     float specularFactor = max( dot(camera_direction, reflected_light), 0.0);
     specularFactor = pow(specularFactor, specularPower);
-    specColour = speculrC * specularFactor * material.reflectance * vec4(light.colour, 1.0);
+    specColour = speculrC * specularFactor * material.reflectance * light.intensity * vec4(light.colour, 1.0);
 
     // Attenuation
     float distance = length(light_direction);


### PR DESCRIPTION
The frag shader here is missing the light intensity

Based on the the book here - https://ahbejarano.gitbook.io/lwjglgamedev/chapter10#specular-component
`specularColour∗lColour∗reflectance∗specularFactor∗intensity`

even though it later also provides the following sample code. 
`specColour = speculrC * specularFactor * material.reflectance * vec4(light.colour, 1.0);`

The function is later corrected in chaper 11 when refactoring out for calculating the components for Point + Directional lights.
https://github.com/lwjglgamedev/lwjglbook-bookcontents/blob/266d58d8270be6f29ab19ee3ac6f22f19ab16d40/chapter11/chapter11.md?plain=1#L162