### PR TITLE
Bug/missing light intensity specular component

### DIFF
--- a/chapter10/src/main/resources/shaders/fragment.fs
+++ b/chapter10/src/main/resources/shaders/fragment.fs
@@ -74,7 +74,7 @@ vec4 calcPointLight(PointLight light, vec3 position, vec3 normal)
     vec3 reflected_light = normalize(reflect(from_light_source, normal));
     float specularFactor = max( dot(camera_direction, reflected_light), 0.0);
     specularFactor = pow(specularFactor, specularPower);
-    specColour = speculrC * specularFactor * material.reflectance * light.intensity * vec4(light.colour, 1.0);
+    specColour = speculrC * light_intensity * specularFactor * material.reflectance * vec4(light_colour, 1.0);
 
     // Attenuation
     float distance = length(light_direction);

--- a/chapter10/src/main/resources/shaders/fragment.fs
+++ b/chapter10/src/main/resources/shaders/fragment.fs
@@ -74,7 +74,7 @@ vec4 calcPointLight(PointLight light, vec3 position, vec3 normal)
     vec3 reflected_light = normalize(reflect(from_light_source, normal));
     float specularFactor = max( dot(camera_direction, reflected_light), 0.0);
     specularFactor = pow(specularFactor, specularPower);
-    specColour = speculrC * specularFactor * material.reflectance * vec4(light.colour, 1.0);
+    specColour = speculrC * specularFactor * material.reflectance * light.intensity * vec4(light.colour, 1.0);
 
     // Attenuation
     float distance = length(light_direction);

--- a/chapter11/c11-p1/src/main/resources/shaders/fragment.fs
+++ b/chapter11/c11-p1/src/main/resources/shaders/fragment.fs
@@ -80,7 +80,7 @@ vec4 calcLightColour(vec3 light_colour, float light_intensity, vec3 position, ve
     vec3 reflected_light = normalize(reflect(from_light_dir , normal));
     float specularFactor = max( dot(camera_direction, reflected_light), 0.0);
     specularFactor = pow(specularFactor, specularPower);
-    specColour = speculrC * light_intensity  * specularFactor * material.reflectance * vec4(light_colour, 1.0);
+    specColour = speculrC * light_intensity * specularFactor * material.reflectance * vec4(light_colour, 1.0);
 
     return (diffuseColour + specColour);
 }

--- a/chapter11/c11-p2/src/main/resources/shaders/fragment.fs
+++ b/chapter11/c11-p2/src/main/resources/shaders/fragment.fs
@@ -88,7 +88,7 @@ vec4 calcLightColour(vec3 light_colour, float light_intensity, vec3 position, ve
     vec3 reflected_light = normalize(reflect(from_light_dir , normal));
     float specularFactor = max( dot(camera_direction, reflected_light), 0.0);
     specularFactor = pow(specularFactor, specularPower);
-    specColour = speculrC * light_intensity  * specularFactor * material.reflectance * vec4(light_colour, 1.0);
+    specColour = speculrC * light_intensity * specularFactor * material.reflectance * vec4(light_colour, 1.0);
 
     return (diffuseColour + specColour);
 }

--- a/chapter11/c11-p3/src/main/resources/shaders/fragment.fs
+++ b/chapter11/c11-p3/src/main/resources/shaders/fragment.fs
@@ -91,7 +91,7 @@ vec4 calcLightColour(vec3 light_colour, float light_intensity, vec3 position, ve
     vec3 reflected_light = normalize(reflect(from_light_dir , normal));
     float specularFactor = max( dot(camera_direction, reflected_light), 0.0);
     specularFactor = pow(specularFactor, specularPower);
-    specColour = speculrC * light_intensity  * specularFactor * material.reflectance * vec4(light_colour, 1.0);
+    specColour = speculrC * light_intensity * specularFactor * material.reflectance * vec4(light_colour, 1.0);
 
     return (diffuseColour + specColour);
 }
@@ -99,7 +99,7 @@ vec4 calcLightColour(vec3 light_colour, float light_intensity, vec3 position, ve
 vec4 calcPointLight(PointLight light, vec3 position, vec3 normal)
 {
     vec3 light_direction = light.position - position;
-    vec3 to_light_dir  = normalize(light_direction);
+    vec3 to_light_dir = normalize(light_direction);
     vec4 light_colour = calcLightColour(light.colour, light.intensity, position, to_light_dir, normal);
 
     // Apply Attenuation


### PR DESCRIPTION
The frag shader here is missing the light intensity

Based on the the book here - https://ahbejarano.gitbook.io/lwjglgamedev/chapter10#specular-component
`specularColour ∗ lColour ∗ reflectance ∗ specularFactor ∗ intensity`

even though it later also provides the following sample code. 
`specColour = speculrC * specularFactor * material.reflectance * vec4(light.colour, 1.0);`

The function is later corrected in chaper 11 where common functionality is refactored out for calculating the components for Point + Directional lights.
https://github.com/lwjglgamedev/lwjglbook-bookcontents/blob/266d58d8270be6f29ab19ee3ac6f22f19ab16d40/chapter11/chapter11.md?plain=1#L162